### PR TITLE
Add MVVM-based JSON text editor skeleton

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,9 +1,6 @@
-﻿<Application x:Class="JsonEditor2.App"
+<Application x:Class="JsonEditor2.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:JsonEditor2"
-             StartupUri="MainWindow.xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
-         
     </Application.Resources>
 </Application>

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,7 +1,16 @@
-﻿using System.Configuration;
-using System.Data;
 using System.Windows;
+using JsonEditor2.Services;
+using JsonEditor2.ViewModels;
 
-public partial class App : Application{
+namespace JsonEditor2{
+    public partial class App : Application{
+        private readonly IFileService fileService = new FileService();
+        private readonly IJsonService jsonService = new JsonService();
+
+        protected override void OnStartup(StartupEventArgs e){
+            base.OnStartup(e);
+            MainWindow window = new MainWindow(fileService, jsonService);
+            window.Show();
+        }
+    }
 }
-

--- a/Controls/TabControls/TabControls.xaml
+++ b/Controls/TabControls/TabControls.xaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="JsonEditor2.Controls.TabControls"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:JsonEditor2.Controls"
+             xmlns:viewModels="clr-namespace:JsonEditor2.ViewModels">
+    <Grid>
+        <TabControl ItemsSource="{Binding Editors}" SelectedItem="{Binding SelectedEditor, Mode=TwoWay}">
+            <TabControl.ItemTemplate>
+                <DataTemplate DataType="{x:Type viewModels:TextEditorViewModel}">
+                    <TextBlock Text="{Binding FilePath, FallbackValue='Untitled'}"/>
+                </DataTemplate>
+            </TabControl.ItemTemplate>
+            <TabControl.ContentTemplate>
+                <DataTemplate DataType="{x:Type viewModels:TextEditorViewModel}">
+                    <local:TextEdit/>
+                </DataTemplate>
+            </TabControl.ContentTemplate>
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/Controls/TabControls/TabControls.xaml.cs
+++ b/Controls/TabControls/TabControls.xaml.cs
@@ -1,0 +1,9 @@
+using System.Windows.Controls;
+
+namespace JsonEditor2.Controls{
+    public partial class TabControls : UserControl{
+        public TabControls(){
+            InitializeComponent();
+        }
+    }
+}

--- a/Controls/TextEdit/TextEdit.xaml
+++ b/Controls/TextEdit/TextEdit.xaml
@@ -1,0 +1,17 @@
+<UserControl x:Class="JsonEditor2.Controls.TextEdit"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d">
+    <Grid>
+        <TextBox Name="Editor"
+                 Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}"
+                 AcceptsReturn="True"
+                 AcceptsTab="True"
+                 VerticalScrollBarVisibility="Auto"
+                 HorizontalScrollBarVisibility="Auto"
+                 AllowDrop="True"
+                 Drop="OnDrop"/>
+    </Grid>
+</UserControl>

--- a/Controls/TextEdit/TextEdit.xaml.cs
+++ b/Controls/TextEdit/TextEdit.xaml.cs
@@ -1,0 +1,23 @@
+using System.Windows;
+using System.Windows.Controls;
+using JsonEditor2.ViewModels;
+
+namespace JsonEditor2.Controls{
+    public partial class TextEdit : UserControl{
+        public TextEdit(){
+            InitializeComponent();
+        }
+
+        private void OnDrop(object sender, DragEventArgs e){
+            if(DataContext is TextEditorViewModel vm){
+                if(e.Data.GetDataPresent(DataFormats.FileDrop)){
+                    string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                    if(files.Length > 0){
+                        vm.FilePath = files[0];
+                        vm.OpenCommand.Execute(null);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,11 +1,24 @@
-﻿<Window x:Class="MainWindow"
+<Window x:Class="JsonEditor2.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
-    <Grid>
-
-    </Grid>
+        xmlns:local="clr-namespace:JsonEditor2.Controls"
+        Title="JsonEditor" Height="450" Width="800">
+    <DockPanel>
+        <ToolBarTray DockPanel.Dock="Top">
+            <ToolBar>
+                <Button Content="New Tab" Command="{Binding NewTabCommand}"/>
+                <Separator/>
+                <TextBlock Text="Indent:" Margin="5,0"/>
+                <TextBox Width="40" Text="{Binding SelectedEditor.IndentWidth, UpdateSourceTrigger=PropertyChanged}"/>
+                <Button Content="Convert" Command="{Binding SelectedEditor.ConvertCommand}" Margin="5,0"/>
+                <Button Content="Format" Command="{Binding SelectedEditor.FormatCommand}" Margin="5,0"/>
+                <Button Content="Open" Command="{Binding SelectedEditor.OpenCommand}" Margin="5,0"/>
+                <Button Content="Save" Command="{Binding SelectedEditor.SaveCommand}" Margin="5,0"/>
+            </ToolBar>
+        </ToolBarTray>
+        <StatusBar DockPanel.Dock="Bottom">
+            <TextBlock Text="{Binding SelectedEditor.Status}"/>
+        </StatusBar>
+        <local:TabControls/>
+    </DockPanel>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,16 +1,12 @@
-﻿using System.Text;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using JsonEditor2.Services;
+using JsonEditor2.ViewModels;
 
-public partial class MainWindow : Window{
-    public MainWindow(){
-        InitializeComponent();
+namespace JsonEditor2{
+    public partial class MainWindow : Window{
+        public MainWindow(IFileService fileService, IJsonService jsonService){
+            InitializeComponent();
+            DataContext = new MainViewModel(fileService, jsonService);
+        }
     }
 }

--- a/Services/FileService.cs
+++ b/Services/FileService.cs
@@ -1,0 +1,13 @@
+using System.IO;
+
+namespace JsonEditor2.Services{
+    public class FileService : IFileService{
+        public string Load(string path){
+            return File.ReadAllText(path);
+        }
+
+        public void Save(string path, string content){
+            File.WriteAllText(path, content);
+        }
+    }
+}

--- a/Services/IFileService.cs
+++ b/Services/IFileService.cs
@@ -1,0 +1,6 @@
+namespace JsonEditor2.Services{
+    public interface IFileService{
+        string Load(string path);
+        void Save(string path, string content);
+    }
+}

--- a/Services/IJsonService.cs
+++ b/Services/IJsonService.cs
@@ -1,0 +1,6 @@
+namespace JsonEditor2.Services{
+    public interface IJsonService{
+        bool TryConvertTabToJson(string input, int indentWidth, out string json, out string error);
+        bool TryFormatJson(string input, int indentWidth, out string formatted, out string error);
+    }
+}

--- a/Services/JsonService.cs
+++ b/Services/JsonService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace JsonEditor2.Services{
+    public class JsonService : IJsonService{
+        public bool TryConvertTabToJson(string input, int indentWidth, out string json, out string error){
+            error = string.Empty;
+            json = string.Empty;
+            try{
+                Dictionary<string, string> dict = new Dictionary<string, string>();
+                string[] lines = input.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach(string line in lines){
+                    string[] parts = line.Split('\t');
+                    if(parts.Length < 2){
+                        error = $"Invalid line: {line}";
+                        return false;
+                    }
+                    dict[parts[0]] = parts[1];
+                }
+                JsonSerializerOptions options = new JsonSerializerOptions{ WriteIndented = true };
+                string raw = JsonSerializer.Serialize(dict, options);
+                json = AdjustIndent(raw, indentWidth);
+                return true;
+            }catch(Exception ex){
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        public bool TryFormatJson(string input, int indentWidth, out string formatted, out string error){
+            error = string.Empty;
+            formatted = string.Empty;
+            try{
+                using JsonDocument doc = JsonDocument.Parse(input);
+                JsonSerializerOptions options = new JsonSerializerOptions{ WriteIndented = true };
+                string raw = JsonSerializer.Serialize(doc.RootElement, options);
+                formatted = AdjustIndent(raw, indentWidth);
+                return true;
+            }catch(JsonException ex){
+                error = $"Line {ex.LineNumber}, Position {ex.BytePositionInLine}: {ex.Message}";
+                return false;
+            }catch(Exception ex){
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        private static string AdjustIndent(string json, int indentWidth){
+            string indent = new string(' ', indentWidth);
+            string[] lines = json.Split('\n');
+            for(int i = 0; i < lines.Length; i++){
+                lines[i] = lines[i].Replace("    ", indent);
+            }
+            return string.Join(Environment.NewLine, lines);
+        }
+    }
+}

--- a/Utils/ExtendsString/Repeat.cs
+++ b/Utils/ExtendsString/Repeat.cs
@@ -1,7 +1,10 @@
+using System;
+using System.Linq;
+
 namespace Utils{
     public static partial class ExtendsString{
         public static string Repeat(this string str, int count){
-            if (count < 1) throw new ArgumentOutOfRangeException(nameof(count));
+            if(count < 1) throw new ArgumentOutOfRangeException(nameof(count));
             return string.Concat(Enumerable.Repeat(str, count));
         }
     }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1,0 +1,41 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using JsonEditor2.Services;
+using Utils;
+
+namespace JsonEditor2.ViewModels{
+    public class MainViewModel : INotifyPropertyChanged{
+        private TextEditorViewModel? selectedEditor;
+        public ObservableCollection<TextEditorViewModel> Editors{ get; }
+        public ICommand NewTabCommand{ get; }
+        private readonly IFileService fileService;
+        private readonly IJsonService jsonService;
+
+        public MainViewModel(IFileService fileService, IJsonService jsonService){
+            this.fileService = fileService;
+            this.jsonService = jsonService;
+            Editors = new ObservableCollection<TextEditorViewModel>();
+            NewTabCommand = new RelayCommand(_ => AddTab());
+            AddTab();
+        }
+
+        public TextEditorViewModel? SelectedEditor{
+            get{ return selectedEditor; }
+            set{ selectedEditor = value; OnPropertyChanged(); }
+        }
+
+        private void AddTab(){
+            TextEditorViewModel editor = new TextEditorViewModel(fileService, jsonService);
+            Editors.Add(editor);
+            SelectedEditor = editor;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string? name = null){
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}

--- a/ViewModels/TextEditorViewModel.cs
+++ b/ViewModels/TextEditorViewModel.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using JsonEditor2.Services;
+using Utils;
+
+namespace JsonEditor2.ViewModels{
+    public class TextEditorViewModel : INotifyPropertyChanged{
+        private readonly IFileService fileService;
+        private readonly IJsonService jsonService;
+        private string text = string.Empty;
+        private string filePath = string.Empty;
+        private string status = string.Empty;
+        private int indentWidth = 4;
+
+        public TextEditorViewModel(IFileService fileService, IJsonService jsonService){
+            this.fileService = fileService;
+            this.jsonService = jsonService;
+            ConvertCommand = new RelayCommand(_ => Convert());
+            FormatCommand = new RelayCommand(_ => Format());
+            OpenCommand = new RelayCommand(_ => Open());
+            SaveCommand = new RelayCommand(_ => Save());
+        }
+
+        public string Text{
+            get{ return text; }
+            set{ text = value; OnPropertyChanged(); }
+        }
+
+        public string Status{
+            get{ return status; }
+            set{ status = value; OnPropertyChanged(); }
+        }
+
+        public ICommand ConvertCommand{ get; }
+        public ICommand FormatCommand{ get; }
+        public ICommand OpenCommand{ get; }
+        public ICommand SaveCommand{ get; }
+
+        public int IndentWidth{
+            get{ return indentWidth; }
+            set{ indentWidth = value; OnPropertyChanged(); }
+        }
+
+        public string FilePath{
+            get{ return filePath; }
+            set{ filePath = value; OnPropertyChanged(); }
+        }
+
+        private void Convert(){
+            if(jsonService.TryConvertTabToJson(Text, IndentWidth, out string json, out string error)){
+                Text = json;
+                Status = "Converted";
+            }else{
+                Status = error;
+            }
+        }
+
+        private void Format(){
+            if(jsonService.TryFormatJson(Text, IndentWidth, out string formatted, out string error)){
+                Text = formatted;
+                Status = "Formatted";
+            }else{
+                Status = error;
+            }
+        }
+
+        private void Open(){
+            if(File.Exists(FilePath)){
+                Text = fileService.Load(FilePath);
+                Status = $"Loaded {Path.GetFileName(FilePath)}";
+            }else{
+                Status = "File not found";
+            }
+        }
+
+        private void Save(){
+            fileService.Save(FilePath, Text);
+            Status = $"Saved {Path.GetFileName(FilePath)}";
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string? name = null){
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement services for file I/O and JSON processing
- implement view models for tabbed text editing
- implement TextEdit and TabControls user controls
- restructure App and MainWindow for DI-based MVVM
- add basic UI with toolbar, status bar and tabbed editor

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bdf66229c8326b7324ece00da1f11