### PR TITLE
Implement Japanese tab UI improvements

### DIFF
--- a/Controls/TabControls/TabControls.xaml
+++ b/Controls/TabControls/TabControls.xaml
@@ -4,10 +4,21 @@
              xmlns:local="clr-namespace:JsonEditor2.Controls"
              xmlns:viewModels="clr-namespace:JsonEditor2.ViewModels">
     <Grid>
-        <TabControl ItemsSource="{Binding Editors}" SelectedItem="{Binding SelectedEditor, Mode=TwoWay}">
+        <TabControl x:Name="Tabs"
+                    SelectedItem="{Binding SelectedEditor, Mode=TwoWay}"
+                    SelectionChanged="OnSelectionChanged">
+            <TabControl.Resources>
+                <CollectionViewSource x:Key="EditorsSource" Source="{Binding Editors}"/>
+            </TabControl.Resources>
+            <TabControl.ItemsSource>
+                <CompositeCollection>
+                    <CollectionContainer Collection="{Binding Source={StaticResource EditorsSource}}"/>
+                    <TabItem Header="+"/>
+                </CompositeCollection>
+            </TabControl.ItemsSource>
             <TabControl.ItemTemplate>
                 <DataTemplate DataType="{x:Type viewModels:TextEditorViewModel}">
-                    <TextBlock Text="{Binding FilePath, FallbackValue='Untitled'}"/>
+                    <TextBlock Text="{Binding Title}"/>
                 </DataTemplate>
             </TabControl.ItemTemplate>
             <TabControl.ContentTemplate>

--- a/Controls/TabControls/TabControls.xaml.cs
+++ b/Controls/TabControls/TabControls.xaml.cs
@@ -1,9 +1,19 @@
 using System.Windows.Controls;
+using JsonEditor2.ViewModels;
 
 namespace JsonEditor2.Controls{
     public partial class TabControls : UserControl{
         public TabControls(){
             InitializeComponent();
+        }
+
+        private void OnSelectionChanged(object sender, SelectionChangedEventArgs e){
+            if(Tabs.SelectedItem is TabItem){
+                if(DataContext is MainViewModel vm){
+                    vm.NewTabCommand.Execute(null);
+                    Tabs.SelectedIndex = vm.Editors.Count - 1;
+                }
+            }
         }
     }
 }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -2,18 +2,16 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:JsonEditor2.Controls"
-        Title="JsonEditor" Height="450" Width="800">
+        Title="Jsonエディター" Height="450" Width="800">
     <DockPanel>
         <ToolBarTray DockPanel.Dock="Top">
             <ToolBar>
-                <Button Content="New Tab" Command="{Binding NewTabCommand}"/>
-                <Separator/>
-                <TextBlock Text="Indent:" Margin="5,0"/>
+                <TextBlock Text="インデント:" Margin="5,0"/>
                 <TextBox Width="40" Text="{Binding SelectedEditor.IndentWidth, UpdateSourceTrigger=PropertyChanged}"/>
-                <Button Content="Convert" Command="{Binding SelectedEditor.ConvertCommand}" Margin="5,0"/>
-                <Button Content="Format" Command="{Binding SelectedEditor.FormatCommand}" Margin="5,0"/>
-                <Button Content="Open" Command="{Binding SelectedEditor.OpenCommand}" Margin="5,0"/>
-                <Button Content="Save" Command="{Binding SelectedEditor.SaveCommand}" Margin="5,0"/>
+                <Button Content="変換" Command="{Binding SelectedEditor.ConvertCommand}" Margin="5,0"/>
+                <Button Content="整形" Command="{Binding SelectedEditor.FormatCommand}" Margin="5,0"/>
+                <Button Content="開く" Command="{Binding SelectedEditor.OpenCommand}" Margin="5,0"/>
+                <Button Content="保存" Command="{Binding SelectedEditor.SaveCommand}" Margin="5,0"/>
             </ToolBar>
         </ToolBarTray>
         <StatusBar DockPanel.Dock="Bottom">

--- a/ViewModels/TextEditorViewModel.cs
+++ b/ViewModels/TextEditorViewModel.cs
@@ -13,6 +13,8 @@ namespace JsonEditor2.ViewModels{
         private string filePath = string.Empty;
         private string status = string.Empty;
         private int indentWidth = 4;
+        private string title = string.Empty;
+        private static int newFileCounter = 1;
 
         public TextEditorViewModel(IFileService fileService, IJsonService jsonService){
             this.fileService = fileService;
@@ -21,6 +23,7 @@ namespace JsonEditor2.ViewModels{
             FormatCommand = new RelayCommand(_ => Format());
             OpenCommand = new RelayCommand(_ => Open());
             SaveCommand = new RelayCommand(_ => Save());
+            Title = $"新規テキスト_{newFileCounter++}";
         }
 
         public string Text{
@@ -43,15 +46,28 @@ namespace JsonEditor2.ViewModels{
             set{ indentWidth = value; OnPropertyChanged(); }
         }
 
+        public string Title{
+            get{ return title; }
+            private set{ title = value; OnPropertyChanged(); }
+        }
+
         public string FilePath{
             get{ return filePath; }
-            set{ filePath = value; OnPropertyChanged(); }
+            set{
+                filePath = value;
+                if(string.IsNullOrEmpty(filePath)){
+                    Title = $"新規テキスト_{newFileCounter++}";
+                }else{
+                    Title = Path.GetFileName(filePath);
+                }
+                OnPropertyChanged();
+            }
         }
 
         private void Convert(){
             if(jsonService.TryConvertTabToJson(Text, IndentWidth, out string json, out string error)){
                 Text = json;
-                Status = "Converted";
+                Status = "変換しました";
             }else{
                 Status = error;
             }
@@ -60,7 +76,7 @@ namespace JsonEditor2.ViewModels{
         private void Format(){
             if(jsonService.TryFormatJson(Text, IndentWidth, out string formatted, out string error)){
                 Text = formatted;
-                Status = "Formatted";
+                Status = "整形しました";
             }else{
                 Status = error;
             }
@@ -69,15 +85,15 @@ namespace JsonEditor2.ViewModels{
         private void Open(){
             if(File.Exists(FilePath)){
                 Text = fileService.Load(FilePath);
-                Status = $"Loaded {Path.GetFileName(FilePath)}";
+                Status = $"{Path.GetFileName(FilePath)} を読み込みました";
             }else{
-                Status = "File not found";
+                Status = "ファイルが見つかりません";
             }
         }
 
         private void Save(){
             fileService.Save(FilePath, Text);
-            Status = $"Saved {Path.GetFileName(FilePath)}";
+            Status = $"{Path.GetFileName(FilePath)} を保存しました";
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;


### PR DESCRIPTION
## Summary
- display filenames or new file numbering in tabs
- add plus-tab for creating new tabs via TabControls
- localize toolbar controls and status messages to Japanese

## Testing
- `dotnet build` *(fails: NETSDK1045 unsupported target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687be1d25a308326beab41e0444459fc