### PR TITLE
Add JSON case conversion and tab close buttons

### DIFF
--- a/Controls/TabControls/TabControls.xaml
+++ b/Controls/TabControls/TabControls.xaml
@@ -18,7 +18,14 @@
             </TabControl.ItemsSource>
             <TabControl.ItemTemplate>
                 <DataTemplate DataType="{x:Type viewModels:TextEditorViewModel}">
-                    <TextBlock Text="{Binding Title}"/>
+                    <DockPanel LastChildFill="False" Orientation="Horizontal">
+                        <TextBlock Text="{Binding Title}" Margin="0,0,5,0"/>
+                        <Button Content="x"
+                                Width="16" Height="16"
+                                Padding="0" Margin="5,0,0,0"
+                                Command="{Binding DataContext.CloseTabCommand, RelativeSource={RelativeSource AncestorType=local:TabControls}}"
+                                CommandParameter="{Binding}"/>
+                    </DockPanel>
                 </DataTemplate>
             </TabControl.ItemTemplate>
             <TabControl.ContentTemplate>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -12,6 +12,8 @@
                 <TextBox Width="40" Text="{Binding SelectedEditor.IndentWidth, UpdateSourceTrigger=PropertyChanged}"/>
                 <Button Content="変換" Command="{Binding SelectedEditor.ConvertCommand}" Margin="5,0"/>
                 <Button Content="整形" Command="{Binding SelectedEditor.FormatCommand}" Margin="5,0"/>
+                <Button Content="UpperCamel" Command="{Binding SelectedEditor.ToUpperCamelCommand}" Margin="5,0"/>
+                <Button Content="snake_case" Command="{Binding SelectedEditor.ToSnakeCaseCommand}" Margin="5,0"/>
             </ToolBar>
         </ToolBarTray>
         <StatusBar DockPanel.Dock="Bottom">

--- a/Services/Json/ConvertPropertyNames.cs
+++ b/Services/Json/ConvertPropertyNames.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Linq;
+
+namespace Services{
+    public partial class JsonService : IJsonService{
+        public bool TryToUpperCamel(string input, int indentWidth, out string converted, out string error){
+            return TryRenameProperties(input, indentWidth, ToUpperCamel, out converted, out error);
+        }
+
+        public bool TryToSnakeCase(string input, int indentWidth, out string converted, out string error){
+            return TryRenameProperties(input, indentWidth, ToSnakeCase, out converted, out error);
+        }
+
+        private static bool TryRenameProperties(string input, int indentWidth, Func<string, string> converter, out string result, out string error){
+            error = string.Empty;
+            result = string.Empty;
+            try{
+                JsonNode root = JsonNode.Parse(input)!;
+                Rename(root);
+                JsonSerializerOptions options = new JsonSerializerOptions{ WriteIndented = true };
+                string raw = JsonSerializer.Serialize(root, options);
+                result = AdjustIndent(raw, indentWidth);
+                return true;
+            }catch(JsonException ex){
+                error = $"Line {ex.LineNumber}, Position {ex.BytePositionInLine}: {ex.Message}";
+                return false;
+            }catch(Exception ex){
+                error = ex.Message;
+                return false;
+            }
+
+            void Rename(JsonNode? node){
+                if(node is JsonObject obj){
+                    var props = obj.ToList();
+                    foreach(var p in props){
+                        obj.Remove(p.Key);
+                    }
+                    foreach(var p in props){
+                        string newName = converter(p.Key);
+                        Rename(p.Value);
+                        obj[newName] = p.Value;
+                    }
+                }else if(node is JsonArray arr){
+                    foreach(JsonNode? child in arr){
+                        Rename(child);
+                    }
+                }
+            }
+        }
+
+        private static string ToUpperCamel(string name){
+            if(string.IsNullOrEmpty(name)) return name;
+            if(name.Length == 1) return char.ToUpperInvariant(name[0]).ToString();
+            return char.ToUpperInvariant(name[0]) + name.Substring(1);
+        }
+
+        private static string ToSnakeCase(string name){
+            if(string.IsNullOrEmpty(name)) return name;
+            StringBuilder sb = new StringBuilder();
+            for(int i = 0; i < name.Length; i++){
+                char c = name[i];
+                if(char.IsUpper(c)){
+                    if(i > 0) sb.Append('_');
+                    sb.Append(char.ToLowerInvariant(c));
+                }else{
+                    sb.Append(c);
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/Services/Json/IJsonService.cs
+++ b/Services/Json/IJsonService.cs
@@ -2,5 +2,7 @@ namespace Services{
     public interface IJsonService{
         bool TryConvertTabToJson(string input, int indentWidth, out string json, out string error);
         bool TryFormatJson(string input, int indentWidth, out string formatted, out string error);
+        bool TryToUpperCamel(string input, int indentWidth, out string converted, out string error);
+        bool TryToSnakeCase(string input, int indentWidth, out string converted, out string error);
     }
 }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -10,6 +10,7 @@ namespace ViewModels{
         private TextEditorViewModel? selectedEditor;
         public ObservableCollection<TextEditorViewModel> Editors{ get; }
         public ICommand NewTabCommand{ get; }
+        public ICommand CloseTabCommand{ get; }
         private readonly IFileService fileService;
         private readonly IJsonService jsonService;
 
@@ -18,6 +19,7 @@ namespace ViewModels{
             this.jsonService = jsonService;
             Editors = new ObservableCollection<TextEditorViewModel>();
             NewTabCommand = new RelayCommand(_ => AddTab());
+            CloseTabCommand = new RelayCommand(e => RemoveTab(e as TextEditorViewModel), e => e is TextEditorViewModel);
             AddTab();
         }
 
@@ -30,6 +32,19 @@ namespace ViewModels{
             TextEditorViewModel editor = new TextEditorViewModel(fileService, jsonService);
             Editors.Add(editor);
             SelectedEditor = editor;
+        }
+
+        private void RemoveTab(TextEditorViewModel? editor){
+            if(editor == null) return;
+            int index = Editors.IndexOf(editor);
+            if(index >= 0){
+                Editors.RemoveAt(index);
+                if(Editors.Count == 0){
+                    AddTab();
+                }else{
+                    SelectedEditor = Editors[Math.Min(index, Editors.Count - 1)];
+                }
+            }
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/ViewModels/TextEditorViewModel.cs
+++ b/ViewModels/TextEditorViewModel.cs
@@ -25,6 +25,8 @@ namespace ViewModels{
             this.jsonService = jsonService;
             ConvertCommand = new RelayCommand(_ => Convert());
             FormatCommand = new RelayCommand(_ => Format());
+            ToUpperCamelCommand = new RelayCommand(_ => ToUpperCamel());
+            ToSnakeCaseCommand = new RelayCommand(_ => ToSnakeCase());
             OpenCommand = new RelayCommand(_ => Open());
             SaveCommand = new RelayCommand(_ => Save());
             Title = $"新規テキスト_{newFileCounter++}";
@@ -46,6 +48,10 @@ namespace ViewModels{
         public ICommand ConvertCommand{ get; }
         // JSONを整形するコマンド
         public ICommand FormatCommand{ get; }
+        // プロパティ名をUpperCamelに変換するコマンド
+        public ICommand ToUpperCamelCommand{ get; }
+        // プロパティ名をsnake_caseに変換するコマンド
+        public ICommand ToSnakeCaseCommand{ get; }
         // ファイルを開くコマンド
         public ICommand OpenCommand{ get; }
         // ファイルを保存するコマンド
@@ -92,6 +98,24 @@ namespace ViewModels{
             if(jsonService.TryFormatJson(Text, IndentWidth, out string formatted, out string error)){
                 Text = formatted;
                 Status = "整形しました";
+            }else{
+                Status = error;
+            }
+        }
+
+        private void ToUpperCamel(){
+            if(jsonService.TryToUpperCamel(Text, IndentWidth, out string converted, out string error)){
+                Text = converted;
+                Status = "UpperCamelに変換しました";
+            }else{
+                Status = error;
+            }
+        }
+
+        private void ToSnakeCase(){
+            if(jsonService.TryToSnakeCase(Text, IndentWidth, out string converted, out string error)){
+                Text = converted;
+                Status = "snake_caseに変換しました";
             }else{
                 Status = error;
             }


### PR DESCRIPTION
## Summary
- add close button to each tab
- add button actions to convert JSON property names to UpperCamel and snake_case
- implement JSON service functions to rename JSON properties
- support tab closing with a new command

## Testing
- `dotnet build` *(fails: NETSDK1045 - SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687befd300c88326beb6bfd29789ed0f