### PR TITLE
Fix startup by wrapping App class in namespace

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -2,13 +2,15 @@ using System.Windows;
 using Services;
 using ViewModels;
 
-public partial class App : Application{
-    private readonly IFileService fileService = new FileService();
-    private readonly IJsonService jsonService = new JsonService();
+namespace JsonEditor2{
+    public partial class App : Application{
+        private readonly IFileService fileService = new FileService();
+        private readonly IJsonService jsonService = new JsonService();
 
-    protected override void OnStartup(StartupEventArgs e){
-        base.OnStartup(e);
-        MainWindow window = new MainWindow(fileService, jsonService);
-        window.Show();
+        protected override void OnStartup(StartupEventArgs e){
+            base.OnStartup(e);
+            MainWindow window = new MainWindow(fileService, jsonService);
+            window.Show();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure App.xaml.cs matches the x:Class namespace so WPF startup runs

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bf35faa98832683d376756da279e7