### PR TITLE
Implement indentation and settings

### DIFF
--- a/Controls/TabControls/TabControls.xaml.cs
+++ b/Controls/TabControls/TabControls.xaml.cs
@@ -7,6 +7,8 @@ namespace Controls{
             InitializeComponent();
         }
 
+        public TextEdit? SelectedTextEdit => Tabs.SelectedContent as TextEdit;
+
         private void OnSelectionChanged(object sender, SelectionChangedEventArgs e){
             if(Tabs.SelectedItem is TabItem){
                 if(DataContext is MainViewModel vm){

--- a/Controls/TextEdit/TextEdit.xaml
+++ b/Controls/TextEdit/TextEdit.xaml
@@ -6,6 +6,7 @@
              mc:Ignorable="d">
     <Grid>
         <TextBox Name="Editor"
+                 FontFamily="MS Gothic"
                  Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}"
                  AcceptsReturn="True"
                  AcceptsTab="True"

--- a/Controls/TextEdit/TextEdit.xaml.cs
+++ b/Controls/TextEdit/TextEdit.xaml.cs
@@ -1,11 +1,60 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using ViewModels;
 
 namespace Controls{
     public partial class TextEdit : UserControl{
         public TextEdit(){
             InitializeComponent();
+            Editor.PreviewKeyDown += OnPreviewKeyDown;
+        }
+
+        public void IndentSelection(){
+            ModifySelection(true);
+        }
+
+        public void UnindentSelection(){
+            ModifySelection(false);
+        }
+
+        private void OnPreviewKeyDown(object sender, KeyEventArgs e){
+            if(EditorSettings.IndentGesture.Matches(null, e)){
+                IndentSelection();
+                e.Handled = true;
+            }else if(EditorSettings.UnindentGesture.Matches(null, e)){
+                UnindentSelection();
+                e.Handled = true;
+            }
+        }
+
+        private void ModifySelection(bool indent){
+            string text = Editor.Text.Replace("\r\n", "\n");
+            string[] lines = text.Split('\n');
+            int startLine = Editor.GetLineIndexFromCharacterIndex(Editor.SelectionStart);
+            int endLine = Editor.GetLineIndexFromCharacterIndex(Editor.SelectionStart + Editor.SelectionLength);
+
+            int delta = 0;
+            string indentStr = EditorSettings.IndentString;
+
+            for(int i = startLine; i <= endLine && i < lines.Length; i++){
+                string line = lines[i];
+                int colon = line.IndexOf(':');
+                if(colon <= 0) continue;
+
+                if(indent){
+                    line = line.Insert(colon, indentStr);
+                    delta += indentStr.Length;
+                }else if(colon >= indentStr.Length && line.Substring(colon - indentStr.Length, indentStr.Length) == indentStr){
+                    line = line.Remove(colon - indentStr.Length, indentStr.Length);
+                    delta -= indentStr.Length;
+                }
+                lines[i] = line;
+            }
+
+            Editor.Text = string.Join(System.Environment.NewLine, lines);
+            Editor.SelectionStart = Editor.GetCharacterIndexFromLineIndex(startLine);
+            Editor.SelectionLength = System.Math.Max(0, (Editor.GetCharacterIndexFromLineIndex(endLine) + lines[endLine].Length) - Editor.SelectionStart + delta);
         }
 
         private void OnDrop(object sender, DragEventArgs e){

--- a/EditorSettings.cs
+++ b/EditorSettings.cs
@@ -1,0 +1,29 @@
+using System.Windows.Input;
+using ViewModels;
+
+public static class EditorSettings{
+    public static string IndentString { get; private set; } = new string(' ', 4);
+    public static KeyGesture IndentGesture { get; private set; } = new KeyGesture(Key.Tab);
+    public static KeyGesture UnindentGesture { get; private set; } = new KeyGesture(Key.Tab, ModifierKeys.Shift);
+
+    public static void Apply(SettingsViewModel vm){
+        switch(vm.IndentStyle){
+            case "2 Spaces":
+                IndentString = new string(' ', 2);
+                break;
+            case "4 Spaces":
+                IndentString = new string(' ', 4);
+                break;
+            case "Tab":
+                IndentString = "\t";
+                break;
+        }
+        KeyGestureConverter conv = new KeyGestureConverter();
+        if(conv.ConvertFromString(vm.IndentShortcut) is KeyGesture kg1){
+            IndentGesture = kg1;
+        }
+        if(conv.ConvertFromString(vm.UnindentShortcut) is KeyGesture kg2){
+            UnindentGesture = kg2;
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -14,11 +14,14 @@
                 <Button Content="整形" Command="{Binding SelectedEditor.FormatCommand}" Margin="5,0"/>
                 <Button Content="UpperCamel" Command="{Binding SelectedEditor.ToUpperCamelCommand}" Margin="5,0"/>
                 <Button Content="snake_case" Command="{Binding SelectedEditor.ToSnakeCaseCommand}" Margin="5,0"/>
+                <Button Content="インデント" Click="OnIndent" Margin="5,0"/>
+                <Button Content="逆インデント" Click="OnUnindent" Margin="5,0"/>
+                <Button Content="設定" Click="OnSettings" Margin="5,0"/>
             </ToolBar>
         </ToolBarTray>
         <StatusBar DockPanel.Dock="Bottom">
             <TextBlock Text="{Binding SelectedEditor.Status}"/>
         </StatusBar>
-        <local:TabControls/>
+        <local:TabControls x:Name="TabsControl"/>
     </DockPanel>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,10 +1,24 @@
 using System.Windows;
 using Services;
 using ViewModels;
+using Views;
 
 public partial class MainWindow : Window{
     public MainWindow(IFileService fileService, IJsonService jsonService){
         InitializeComponent();
         DataContext = new MainViewModel(fileService, jsonService);
+    }
+
+    private void OnIndent(object sender, RoutedEventArgs e){
+        TabsControl.SelectedTextEdit?.IndentSelection();
+    }
+
+    private void OnUnindent(object sender, RoutedEventArgs e){
+        TabsControl.SelectedTextEdit?.UnindentSelection();
+    }
+
+    private void OnSettings(object sender, RoutedEventArgs e){
+        SettingsWindow win = new SettingsWindow(){ Owner = this };
+        win.ShowDialog();
     }
 }

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace ViewModels{
+    public class SettingsViewModel : INotifyPropertyChanged{
+        private string indentStyle = "4 Spaces";
+        private string indentShortcut = "Tab";
+        private string unindentShortcut = "Shift+Tab";
+
+        public string IndentStyle{
+            get => indentStyle;
+            set{ indentStyle = value; OnPropertyChanged(); }
+        }
+        public string IndentShortcut{
+            get => indentShortcut;
+            set{ indentShortcut = value; OnPropertyChanged(); }
+        }
+        public string UnindentShortcut{
+            get => unindentShortcut;
+            set{ unindentShortcut = value; OnPropertyChanged(); }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? name = null){
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}

--- a/Views/SettingsWindow.xaml
+++ b/Views/SettingsWindow.xaml
@@ -1,0 +1,24 @@
+<Window x:Class="Views.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Settings" SizeToContent="WidthAndHeight">
+    <StackPanel Margin="10">
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <TextBlock Text="Indent Style:" Width="100"/>
+            <ComboBox Width="150" SelectedItem="{Binding IndentStyle}">
+                <ComboBoxItem Content="2 Spaces"/>
+                <ComboBoxItem Content="4 Spaces"/>
+                <ComboBoxItem Content="Tab"/>
+            </ComboBox>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <TextBlock Text="Indent Shortcut:" Width="100"/>
+            <TextBox Width="150" Text="{Binding IndentShortcut}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <TextBlock Text="Unindent Shortcut:" Width="100"/>
+            <TextBox Width="150" Text="{Binding UnindentShortcut}"/>
+        </StackPanel>
+        <Button Content="OK" Width="80" HorizontalAlignment="Right" Click="OnOk"/>
+    </StackPanel>
+</Window>

--- a/Views/SettingsWindow.xaml.cs
+++ b/Views/SettingsWindow.xaml.cs
@@ -1,0 +1,22 @@
+using System.Windows;
+using System.Windows.Input;
+using ViewModels;
+
+namespace Views{
+    public partial class SettingsWindow : Window{
+        public SettingsViewModel ViewModel { get; } = new SettingsViewModel();
+        public SettingsWindow(){
+            InitializeComponent();
+            DataContext = ViewModel;
+            KeyGestureConverter conv = new KeyGestureConverter();
+            ViewModel.IndentStyle = EditorSettings.IndentString == "\t" ? "Tab" :
+                (EditorSettings.IndentString.Length == 2 ? "2 Spaces" : "4 Spaces");
+            ViewModel.IndentShortcut = conv.ConvertToString(EditorSettings.IndentGesture)!;
+            ViewModel.UnindentShortcut = conv.ConvertToString(EditorSettings.UnindentGesture)!;
+        }
+        private void OnOk(object sender, RoutedEventArgs e){
+            EditorSettings.Apply(ViewModel);
+            DialogResult = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set MS Gothic font for the editor
- add editable indent/outdent logic using Tab or Shift+Tab
- provide new Settings window to configure indent style and shortcuts
- add toolbar buttons for indentation, outdentation and settings

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfdab963c83269cd9c10e800396c4