### PR TITLE
Refactor selection handling and indent logic

### DIFF
--- a/Controls/TextEdit/TextLine.cs
+++ b/Controls/TextEdit/TextLine.cs
@@ -1,0 +1,5 @@
+namespace Controls{
+    public class TextLine{
+        public string Text { get; set; } = string.Empty;
+    }
+}

--- a/Services/Text/IndentService.cs
+++ b/Services/Text/IndentService.cs
@@ -1,36 +1,36 @@
 using System;
-using System.Windows.Controls;
+using System.Collections.Generic;
+using Controls;
 using Utils;
 
 namespace Services{
     public static class IndentService{
         // 選択された行をインデントまたはインデント解除します。
         // Tab入力はEditorSettings.IndentStringで定義されたスペースに置き換えられます。
-        public static void ModifySelection(TextBox editor, bool indent){
-            string text = editor.Text.Replace("\r\n", "\n");
-            string[] lines = text.Split('\n');
-            int startLine = editor.GetLineIndexFromCharacterIndex(editor.SelectionStart);
-            int endLine = editor.GetLineIndexFromCharacterIndex(editor.SelectionStart + editor.SelectionLength);
+        public static void ModifySelection(List<TextLine> lines, int startLine, int endLine, bool indent){
+            string indentStr = EditorSettings.IndentString;
 
-            int delta = 0;
-            // Define the indent string here or reference your settings class appropriately.
-            string indentStr = " ".Repeat(4); // 4 spaces as default, replace with your preferred indent or settings reference
-
-            for(int i = startLine; i <= endLine && i < lines.Length; i++){
-                string line = lines[i];
-                if(indent){
-                    line = indentStr + line.TrimStart('\t');
-                    delta += indentStr.Length;
-                }else if(line.StartsWith(indentStr)){
-                    line = line.Substring(indentStr.Length);
-                    delta -= indentStr.Length;
+            for(int i = startLine; i <= endLine && i < lines.Count; i++){
+                string line = lines[i].Text;
+                int colonIndex = line.IndexOf(':');
+                if(colonIndex >= 0){
+                    string before = line.Substring(0, colonIndex);
+                    string after = line.Substring(colonIndex);
+                    if(indent){
+                        before = indentStr + before;
+                    }else if(before.StartsWith(indentStr)){
+                        before = before.Substring(indentStr.Length);
+                    }
+                    line = before + after;
+                }else{
+                    if(indent){
+                        line = indentStr + line.TrimStart('\t');
+                    }else if(line.StartsWith(indentStr)){
+                        line = line.Substring(indentStr.Length);
+                    }
                 }
-                lines[i] = line;
+                lines[i].Text = line;
             }
-
-            editor.Text = string.Join(Environment.NewLine, lines);
-            editor.SelectionStart = editor.GetCharacterIndexFromLineIndex(startLine);
-            editor.SelectionLength = Math.Max(0, (editor.GetCharacterIndexFromLineIndex(endLine) + lines[endLine].Length) - editor.SelectionStart + delta);
         }
     }
 }


### PR DESCRIPTION
## Summary
- create `TextLine` class to store editor lines
- maintain list of `TextLine` in `TextEdit`
- expose line range info for selection
- move selection range logic out of `IndentService`
- update indent logic to modify text before `:`

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687c0aa58bc48326bb4465539cf126ca