### PR TITLE
Draw line numbers from TextLine list

### DIFF
--- a/Controls/TextEdit/TextEdit.xaml
+++ b/Controls/TextEdit/TextEdit.xaml
@@ -16,7 +16,14 @@
                  Background="#FFEEEEEE"
                  BorderThickness="0"
                  SelectionMode="Extended"
-                 SelectionChanged="OnLineNumberSelection"/>
+                 ItemsSource="{Binding Lines, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                 SelectionChanged="OnLineNumberSelection">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding LineNumber}"/>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
         <TextBox Name="Editor"
                  Grid.Column="1"
                  FontFamily="MS Gothic"

--- a/Controls/TextEdit/TextEdit.xaml.cs
+++ b/Controls/TextEdit/TextEdit.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -15,7 +16,9 @@ namespace Controls{
         private readonly Stack<string> redoStack = new Stack<string>();
         private string lastText = string.Empty;
         private bool internalChange = false;
-        private readonly List<TextLine> lines = new List<TextLine>();
+        private readonly ObservableCollection<TextLine> lines = new();
+
+        public ObservableCollection<TextLine> Lines => lines;
 
         public TextEdit(){
             InitializeComponent();
@@ -114,10 +117,7 @@ namespace Controls{
         }
 
         private void UpdateLineNumbers(){
-            int count = lines.Count;
-            List<string> nums = new();
-            for(int i = 1; i <= count; i++) nums.Add(i.ToString());
-            lineNumbers.ItemsSource = nums;
+            lineNumbers.ItemsSource = lines;
             UpdateLineNumberVisibility();
         }
 
@@ -128,12 +128,13 @@ namespace Controls{
         private void UpdateLineData(){
             lines.Clear();
             string[] rawLines = editorControl.Text.Replace("\r\n", "\n").Split('\n');
+            int num = 1;
             foreach(string l in rawLines){
-                lines.Add(new TextLine{ Text = l });
+                lines.Add(new TextLine{ LineNumber = num++, Text = l });
             }
         }
 
-        public (List<TextLine> Lines, int StartLine, int EndLine) GetSelectedLineRange(){
+        public (IList<TextLine> Lines, int StartLine, int EndLine) GetSelectedLineRange(){
             int startLine = editorControl.GetLineIndexFromCharacterIndex(editorControl.SelectionStart);
             int endLine = editorControl.GetLineIndexFromCharacterIndex(editorControl.SelectionStart + editorControl.SelectionLength);
             return (lines, startLine, endLine);

--- a/Services/Text/IndentService.cs
+++ b/Services/Text/IndentService.cs
@@ -7,7 +7,7 @@ namespace Services{
     public static class IndentService{
         // 選択された行をインデントまたはインデント解除します。
         // Tab入力はEditorSettings.IndentStringで定義されたスペースに置き換えられます。
-        public static void ModifySelection(List<TextLine> lines, int startLine, int endLine, bool indent){
+        public static void ModifySelection(IList<TextLine> lines, int startLine, int endLine, bool indent){
             string indentStr = EditorSettings.IndentString;
 
             for(int i = startLine; i <= endLine && i < lines.Count; i++){


### PR DESCRIPTION
## Summary
- expose `Lines` collection from `TextEdit`
- update list data to maintain line numbers
- bind `LineNumbers` ListBox to the `Lines` list
- adjust indent service signature to use `IList<TextLine>`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c941d394c83269e4e84d96eddebb3