### PR TITLE
Fix build errors and expose line control event

### DIFF
--- a/Controls/TextEdit/TextEdit.xaml
+++ b/Controls/TextEdit/TextEdit.xaml
@@ -17,7 +17,8 @@
                  BorderThickness="0"
                  SelectionMode="Extended"
                  ItemsSource="{Binding Lines, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                 SelectionChanged="OnLineNumberSelection">
+                 SelectionChanged="OnLineNumberSelection"
+                 PreviewMouseLeftButtonDown="OnLineNumberMouseDown">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <TextBlock Text="{Binding LineNumber}"/>

--- a/Controls/TextEdit/TextEdit.xaml.cs
+++ b/Controls/TextEdit/TextEdit.xaml.cs
@@ -12,6 +12,7 @@ namespace Controls{
     public partial class TextEdit : UserControl{
         private TextBox editorControl => Editor;
         private ListBox lineNumbers => LineNumbers;
+        public event EventHandler<int>? LineControlRequested;
         private readonly Stack<string> undoStack = new Stack<string>();
         private readonly Stack<string> redoStack = new Stack<string>();
         private string lastText = string.Empty;
@@ -149,6 +150,16 @@ namespace Controls{
             int endPos = editorControl.GetCharacterIndexFromLineIndex(end) + editorControl.GetLineLength(end);
             editorControl.SelectionStart = startPos;
             editorControl.SelectionLength = Math.Max(0, endPos - startPos);
+        }
+
+        // ctrl-click on a line number triggers external control handling
+        private void OnLineNumberMouseDown(object sender, MouseButtonEventArgs e){
+            if((Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control){
+                if(sender is ListBoxItem item && item.DataContext is TextLine line){
+                    LineControlRequested?.Invoke(this, line.LineNumber);
+                    e.Handled = true;
+                }
+            }
         }
     }
 }

--- a/JsonEditor2.csproj
+++ b/JsonEditor2.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <!-- allow building on non-Windows hosts -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- expose `LineControlRequested` event and fire it on Ctrl-click
- ensure XAML contains PreviewMouseLeftButtonDown handler
- allow building on Linux by setting `EnableWindowsTargeting` in the project file

## Testing
- `dotnet build` *(succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_687c980664d883269db258f9ee606fd0