### PR TITLE
Add icons and fix TextEdit build

### DIFF
--- a/Controls/TabControls/TabControls.xaml
+++ b/Controls/TabControls/TabControls.xaml
@@ -20,11 +20,13 @@
                 <DataTemplate DataType="{x:Type viewModels:TextEditorViewModel}">
                     <DockPanel LastChildFill="False">
                         <TextBlock Text="{Binding Title}" Margin="0,0,5,0"/>
-                        <Button Content="x"
-                                Width="16" Height="16"
+                        <Button Width="16" Height="16"
                                 Padding="0" Margin="5,0,0,0"
+                                ToolTip="閉じる"
                                 Command="{Binding DataContext.CloseTabCommand, RelativeSource={RelativeSource AncestorType=local:TabControls}}"
-                                CommandParameter="{Binding}"/>
+                                CommandParameter="{Binding}">
+                            <Image Source="Resources/Icons/close.png" Width="16" Height="16"/>
+                        </Button>
                     </DockPanel>
                 </DataTemplate>
             </TabControl.ItemTemplate>

--- a/Controls/TextEdit/TextEdit.xaml
+++ b/Controls/TextEdit/TextEdit.xaml
@@ -17,8 +17,6 @@
                  BorderThickness="0"
                  SelectionMode="Extended"
                  ItemsSource="{Binding Lines, RelativeSource={RelativeSource AncestorType=UserControl}}"
-
-                 SelectionChanged="OnLineNumberSelection"
                  PreviewMouseLeftButtonDown="OnLineNumberMouseDown">
             <ListBox.ItemTemplate>
                 <DataTemplate>

--- a/Controls/TextEdit/TextEdit.xaml.cs
+++ b/Controls/TextEdit/TextEdit.xaml.cs
@@ -10,12 +10,8 @@ using Services;
 
 namespace Controls{
     public partial class TextEdit : UserControl{
-        private TextBox editorControl => Editor;
-        private ListBox lineNumbers => LineNumbers;
+        private ListBox lineList => LinesList;
         public event EventHandler<int>? LineControlRequested;
-        private readonly Stack<string> undoStack = new Stack<string>();
-        private readonly Stack<string> redoStack = new Stack<string>();
-        private string lastText = string.Empty;
         private bool internalChange = false;
         private readonly ObservableCollection<TextLine> lines = new ObservableCollection<TextLine>();
 

--- a/JsonEditor2.csproj
+++ b/JsonEditor2.csproj
@@ -10,4 +10,8 @@
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Resource Include="Resources/Icons/*.png" />
+  </ItemGroup>
+
 </Project>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -6,17 +6,23 @@
     <DockPanel>
         <ToolBarTray DockPanel.Dock="Top">
             <ToolBar>
-                <Button Content="開く" Command="{Binding SelectedEditor.OpenCommand}" Margin="5,0"/>
-                <Button Content="保存" Command="{Binding SelectedEditor.SaveCommand}" Margin="5,0"/>
+                <Button ToolTip="開く" Content="開く" Command="{Binding SelectedEditor.OpenCommand}" Margin="5,0"/>
+                <Button ToolTip="保存" Content="保存" Command="{Binding SelectedEditor.SaveCommand}" Margin="5,0"/>
                 <TextBlock Text="インデント:" Margin="5,0"/>
                 <TextBox Width="40" Text="{Binding SelectedEditor.IndentWidth, UpdateSourceTrigger=PropertyChanged}"/>
-                <Button Content="変換" Command="{Binding SelectedEditor.ConvertCommand}" Margin="5,0"/>
-                <Button Content="整形" Command="{Binding SelectedEditor.FormatCommand}" Margin="5,0"/>
-                <Button Content="UpperCamel" Command="{Binding SelectedEditor.ToUpperCamelCommand}" Margin="5,0"/>
-                <Button Content="snake_case" Command="{Binding SelectedEditor.ToSnakeCaseCommand}" Margin="5,0"/>
-                <Button Content="インデント" Click="OnIndent" Margin="5,0"/>
-                <Button Content="逆インデント" Click="OnUnindent" Margin="5,0"/>
-                <Button Content="設定" Click="OnSettings" Margin="5,0"/>
+                <Button ToolTip="変換" Content="変換" Command="{Binding SelectedEditor.ConvertCommand}" Margin="5,0"/>
+                <Button ToolTip="整形" Content="整形" Command="{Binding SelectedEditor.FormatCommand}" Margin="5,0"/>
+                <Button ToolTip="UpperCamel" Command="{Binding SelectedEditor.ToUpperCamelCommand}" Margin="5,0">
+                    <Image Source="Resources/Icons/UpperCamel.png" Width="16" Height="16"/>
+                </Button>
+                <Button ToolTip="snake_case" Content="snake_case" Command="{Binding SelectedEditor.ToSnakeCaseCommand}" Margin="5,0"/>
+                <Button ToolTip="インデント" Click="OnIndent" Margin="5,0">
+                    <Image Source="Resources/Icons/Indent.png" Width="16" Height="16"/>
+                </Button>
+                <Button ToolTip="逆インデント" Click="OnUnindent" Margin="5,0">
+                    <Image Source="Resources/Icons/revIndent.png" Width="16" Height="16"/>
+                </Button>
+                <Button ToolTip="設定" Content="設定" Click="OnSettings" Margin="5,0"/>
             </ToolBar>
         </ToolBarTray>
         <StatusBar DockPanel.Dock="Bottom">


### PR DESCRIPTION
## Summary
- display icon buttons in the toolbar
- use icon for close tab button
- remove invalid line selection handler
- ensure icons are bundled as resources
- fix missing controls in TextEdit class

## Testing
- `dotnet build JsonEditor2.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca2008af08326b7e029f77637bdb6