### PR TITLE
Enable editing in TextEdit control

### DIFF
--- a/Controls/TextEdit/TextEdit.xaml
+++ b/Controls/TextEdit/TextEdit.xaml
@@ -6,30 +6,31 @@
              mc:Ignorable="d">
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="30"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
-        
+
         <ListBox x:Name="LinesList"
-                 Grid.ColumnSpan="2"
+                 Grid.Column="0"
                  FontFamily="MS Gothic"
                  Background="Transparent"
                  BorderThickness="0"
-                 SelectionMode="Extended"
                  ItemsSource="{Binding Lines, RelativeSource={RelativeSource AncestorType=UserControl}}"
                  PreviewMouseLeftButtonDown="OnLineNumberMouseDown">
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="20"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="{Binding LineNumber}"/>
-                        <TextBlock Grid.Column="1" Text="{Binding Text}"/>
-                    </Grid>
+                    <TextBlock Text="{Binding LineNumber}" Padding="0,0,2,0"/>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
+
+        <TextBox x:Name="EditorBox"
+                 Grid.Column="1"
+                 FontFamily="MS Gothic"
+                 AcceptsReturn="True"
+                 AcceptsTab="True"
+                 Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}"
+                 VerticalScrollBarVisibility="Auto"
+                 HorizontalScrollBarVisibility="Auto"/>
     </Grid>
 </UserControl>

--- a/Controls/TextEdit/TextEdit.xaml.cs
+++ b/Controls/TextEdit/TextEdit.xaml.cs
@@ -11,6 +11,7 @@ using Services;
 namespace Controls{
     public partial class TextEdit : UserControl{
         private ListBox lineList => LinesList;
+        private TextBox editorBox => EditorBox;
         public event EventHandler<int>? LineControlRequested;
         private bool internalChange = false;
         private readonly ObservableCollection<TextLine> lines = new ObservableCollection<TextLine>();
@@ -21,6 +22,7 @@ namespace Controls{
             InitializeComponent();
             DataContextChanged += OnDataContextChanged;
             EditorSettings.Changed += (_, _) => UpdateLineVisibility();
+            UpdateLineVisibility();
         }
 
         private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e){
@@ -75,9 +77,10 @@ namespace Controls{
         }
 
         public (IList<TextLine> Lines, int StartLine, int EndLine) GetSelectedLineRange(){
-            int start = lineList.SelectedIndex;
-            int end = start + lineList.SelectedItems.Count - 1;
-            if(start < 0) start = end = 0;
+            int startChar = editorBox.SelectionStart;
+            int endChar = startChar + editorBox.SelectionLength;
+            int start = editorBox.GetLineIndexFromCharacterIndex(startChar);
+            int end = editorBox.GetLineIndexFromCharacterIndex(endChar);
             return (lines, start, end);
         }
 


### PR DESCRIPTION
## Summary
- add `TextBox` to the `TextEdit` UI
- handle selection range from the editor for indenting
- keep line numbers in sync with the editor

## Testing
- `dotnet build -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687ca425db588326b8bb0e809663406e