### PR TITLE
Implement TextLine-based editor view

### DIFF
--- a/Controls/TextEdit/TextEdit.xaml
+++ b/Controls/TextEdit/TextEdit.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Controls.TextEdit"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:localSettings="clr-namespace:">
     <Grid>
         <ListBox x:Name="Editor"
                  FontFamily="MS Gothic"
@@ -19,7 +20,8 @@
                                    Text="{Binding LineNumber}"
                                    Padding="2"
                                    Foreground="Gray"
-                                   VerticalAlignment="Center"/>
+                                   VerticalAlignment="Center"
+                                   x:Name="LineNumberBlock"/>
                         <TextBox Grid.Column="1"
                                  Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                  BorderThickness="0"
@@ -27,6 +29,11 @@
                                  AcceptsReturn="False"
                                  AcceptsTab="True"
                                  VerticalAlignment="Center"/>
+                        <Grid.Triggers>
+                            <DataTrigger Binding="{Binding Source={x:Static localSettings:EditorSettings.ShowLineNumbers}}" Value="False">
+                                <Setter TargetName="LineNumberBlock" Property="Visibility" Value="Collapsed"/>
+                            </DataTrigger>
+                        </Grid.Triggers>
                     </Grid>
                 </DataTemplate>
             </ListBox.ItemTemplate>

--- a/Controls/TextEdit/TextLine.cs
+++ b/Controls/TextEdit/TextLine.cs
@@ -1,6 +1,29 @@
-namespace Controls{
-    public class TextLine{
-        public int LineNumber { get; set; }
-        public string Text { get; set; } = string.Empty;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Controls {
+    /// <summary>
+    /// Represents a single editable line in the editor.
+    /// </summary>
+    public class TextLine : INotifyPropertyChanged {
+        private int lineNumber;
+        private string text = string.Empty;
+
+        /// <summary>行番号。</summary>
+        public int LineNumber {
+            get => lineNumber;
+            set { lineNumber = value; OnPropertyChanged(); }
+        }
+
+        /// <summary>行のテキスト。</summary>
+        public string Text {
+            get => text;
+            set { text = value; OnPropertyChanged(); }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }
 }

--- a/EditorSettings.cs
+++ b/EditorSettings.cs
@@ -3,12 +3,25 @@ using System.Text.Json;
 using System.Windows.Input;
 using ViewModels;
 
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
 public static class EditorSettings{
     private const string ShortcutFile = "shortcuts.json";
     public static string IndentString { get; private set; } = new string(' ', 4);
     public static KeyGesture IndentGesture { get; private set; } = new KeyGesture(Key.Tab);
     public static KeyGesture UnindentGesture { get; private set; } = new KeyGesture(Key.Tab, ModifierKeys.Shift);
-    public static bool ShowLineNumbers { get; private set; } = true;
+    private static bool showLineNumbers = true;
+    public static bool ShowLineNumbers {
+        get => showLineNumbers;
+        private set {
+            if(showLineNumbers != value){
+                showLineNumbers = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+    public static event PropertyChangedEventHandler? PropertyChanged;
     public static event EventHandler? Changed;
 
     static EditorSettings(){
@@ -57,6 +70,11 @@ public static class EditorSettings{
             UnindentShortcut = new KeyGestureConverter().ConvertToString(UnindentGesture)!
         };
         File.WriteAllText(ShortcutFile, JsonSerializer.Serialize(conf));
+    }
+
+    private static void OnPropertyChanged([CallerMemberName] string? name = null)
+    {
+        PropertyChanged?.Invoke(null, new PropertyChangedEventArgs(name));
     }
 
     private class ShortcutConfig{

--- a/JsonEditor2.csproj
+++ b/JsonEditor2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
## Summary
- add `TextLine` model with line number and text
- rework `TextEdit` to show and edit each line through a single `ListBox`
- update editor settings to notify when line number visibility changes
- target .NET 8 for easier building
- revert accidental icon modifications and tidy view-model hookups

## Testing
- `dotnet build -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687caa3e4e90832684ac2a81766049d9