### PR TITLE
Fix DataTrigger usage in TextEdit control

### DIFF
--- a/Controls/TextEdit/TextEdit.xaml
+++ b/Controls/TextEdit/TextEdit.xaml
@@ -29,12 +29,12 @@
                                  AcceptsReturn="False"
                                  AcceptsTab="True"
                                  VerticalAlignment="Center"/>
-                        <Grid.Triggers>
-                            <DataTrigger Binding="{Binding Source={x:Static localSettings:EditorSettings.ShowLineNumbers}}" Value="False">
-                                <Setter TargetName="LineNumberBlock" Property="Visibility" Value="Collapsed"/>
-                            </DataTrigger>
-                        </Grid.Triggers>
                     </Grid>
+                    <DataTemplate.Triggers>
+                        <DataTrigger Binding="{Binding Source={x:Static localSettings:EditorSettings.ShowLineNumbers}}" Value="False">
+                            <Setter TargetName="LineNumberBlock" Property="Visibility" Value="Collapsed"/>
+                        </DataTrigger>
+                    </DataTemplate.Triggers>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>


### PR DESCRIPTION
## Summary
- fix crash in `TextEdit.xaml` by moving the `DataTrigger` into `DataTemplate.Triggers`

## Testing
- `dotnet build JsonEditor2.csproj -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687caedfe6308326998afd181fedd267