### PR TITLE
Improve line editing behavior

### DIFF
--- a/Controls/TextEdit/TextEdit.xaml
+++ b/Controls/TextEdit/TextEdit.xaml
@@ -29,6 +29,8 @@
                                  Background="Transparent"
                                  AcceptsReturn="False"
                                  AcceptsTab="True"
+                                 PreviewKeyDown="OnTextBoxPreviewKeyDown"
+                                 DataObject.Pasting="OnTextBoxPasting"
                                  VerticalAlignment="Center"/>
                     </Grid>
                     <DataTemplate.Triggers>

--- a/Controls/TextEdit/TextEdit.xaml.cs
+++ b/Controls/TextEdit/TextEdit.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using ViewModels;
 using Services;
 
@@ -14,12 +15,15 @@ namespace Controls{
         private ListBox lineList => Editor;
         public event EventHandler<int>? LineControlRequested;
         private bool internalChange = false;
+        private readonly DispatcherTimer updateTimer = new();
         private readonly ObservableCollection<TextLine> lines = new();
 
         public ObservableCollection<TextLine> Lines => lines;
 
         public TextEdit(){
             InitializeComponent();
+            updateTimer.Interval = TimeSpan.FromMilliseconds(300);
+            updateTimer.Tick += UpdateTimer_Tick;
             DataContextChanged += OnDataContextChanged;
             EditorSettings.Changed += (_, _) => UpdateLineVisibility();
             UpdateLineVisibility();
@@ -43,6 +47,7 @@ namespace Controls{
 
         private void SetText(string text){
             internalChange = true;
+            updateTimer.Stop();
             foreach(var l in lines)
                 l.PropertyChanged -= OnLineChanged;
 
@@ -62,8 +67,21 @@ namespace Controls{
         {
             if(e.PropertyName == nameof(TextLine.Text))
             {
-                UpdateVmText();
+                ScheduleVmUpdate();
             }
+        }
+
+        private void UpdateTimer_Tick(object? sender, EventArgs e)
+        {
+            updateTimer.Stop();
+            UpdateVmText();
+        }
+
+        private void ScheduleVmUpdate()
+        {
+            if(internalChange) return;
+            updateTimer.Stop();
+            updateTimer.Start();
         }
 
         private void UpdateVmText(){
@@ -85,7 +103,7 @@ namespace Controls{
             var (currentLines, start, end) = GetSelectedLineRange();
             IndentService.ModifySelection(currentLines, start, end, indent);
             Renumber();
-            UpdateVmText();
+            ScheduleVmUpdate();
         }
 
         private void Renumber(){
@@ -114,6 +132,120 @@ namespace Controls{
 
         private void UpdateLineVisibility(){
             lineList.Items.Refresh();
+        }
+
+        private void OnTextBoxPreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if(sender is not TextBox tb) return;
+
+            if(e.Key == Key.Enter)
+            {
+                InsertNewLine(tb);
+                e.Handled = true;
+            }
+            else if(e.Key == Key.V && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control)
+            {
+                if(Clipboard.ContainsText())
+                {
+                    string text = Clipboard.GetText();
+                    if(text.Contains('\n'))
+                    {
+                        PasteMultiline(tb, text);
+                        e.Handled = true;
+                    }
+                }
+            }
+        }
+
+        private void OnTextBoxPasting(object sender, DataObjectPastingEventArgs e)
+        {
+            if(e.DataObject.GetDataPresent(DataFormats.UnicodeText))
+            {
+                string text = e.DataObject.GetData(DataFormats.UnicodeText) as string ?? string.Empty;
+                if(text.Contains('\n') && sender is TextBox tb)
+                {
+                    PasteMultiline(tb, text);
+                    e.CancelCommand();
+                    e.Handled = true;
+                }
+            }
+        }
+
+        private void InsertNewLine(TextBox tb)
+        {
+            int index = lineList.ItemContainerGenerator.IndexFromContainer(lineList.ContainerFromElement(tb));
+            if(index < 0) return;
+
+            TextLine line = lines[index];
+            int caret = tb.CaretIndex;
+            string before = line.Text.Substring(0, Math.Min(caret, line.Text.Length));
+            string after = line.Text.Substring(Math.Min(caret, line.Text.Length));
+
+            line.Text = before;
+            TextLine newLine = new TextLine { Text = after };
+            newLine.PropertyChanged += OnLineChanged;
+            lines.Insert(index + 1, newLine);
+            Renumber();
+            ScheduleVmUpdate();
+
+            lineList.UpdateLayout();
+            if(lineList.ItemContainerGenerator.ContainerFromIndex(index + 1) is ListBoxItem item)
+            {
+                if(FindTextBox(item) is TextBox nextBox)
+                {
+                    nextBox.Focus();
+                    nextBox.CaretIndex = 0;
+                }
+            }
+        }
+
+        private void PasteMultiline(TextBox tb, string text)
+        {
+            int index = lineList.ItemContainerGenerator.IndexFromContainer(lineList.ContainerFromElement(tb));
+            if(index < 0) return;
+
+            text = text.Replace("\r\n", "\n");
+            string[] parts = text.Split('\n');
+
+            TextLine line = lines[index];
+            int caret = tb.CaretIndex;
+            string before = line.Text.Substring(0, Math.Min(caret, line.Text.Length));
+            string after = line.Text.Substring(Math.Min(caret, line.Text.Length));
+
+            line.Text = before + parts[0];
+
+            for(int i = 1; i < parts.Length; i++)
+            {
+                TextLine nl = new TextLine { Text = parts[i] };
+                nl.PropertyChanged += OnLineChanged;
+                lines.Insert(index + i, nl);
+            }
+
+            lines[index + parts.Length - 1].Text += after;
+            Renumber();
+            ScheduleVmUpdate();
+
+            lineList.UpdateLayout();
+            if(lineList.ItemContainerGenerator.ContainerFromIndex(index + parts.Length - 1) is ListBoxItem item)
+            {
+                if(FindTextBox(item) is TextBox nextBox)
+                {
+                    nextBox.Focus();
+                    nextBox.CaretIndex = parts[^1].Length;
+                }
+            }
+        }
+
+        private static TextBox? FindTextBox(DependencyObject parent)
+        {
+            for(int i = 0; i < System.Windows.Media.VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                DependencyObject child = System.Windows.Media.VisualTreeHelper.GetChild(parent, i);
+                if(child is TextBox tb) return tb;
+                var result = FindTextBox(child);
+                if(result != null) return result;
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- reduce `TextEditorViewModel.Text` updates by throttling with `DispatcherTimer`
- handle `Enter` key and paste to split lines
- support multi-line paste from clipboard

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: `Unable to locate package`)*

------
https://chatgpt.com/codex/tasks/task_e_687cb557b2c083269ab8ea00dc3ef974