### PR TITLE
Add selection service & improve range selection

### DIFF
--- a/Controls/TextEdit/TextEdit.Indent.cs
+++ b/Controls/TextEdit/TextEdit.Indent.cs
@@ -13,7 +13,7 @@ namespace Controls{
         }
 
         private void ModifySelection(bool indent){
-            var (currentLines, start, end) = GetSelectedLineRange();
+            var (currentLines, start, end) = SelectionService.GetSelectedLineRange(lines, lineList.SelectedItems, lineList.SelectedIndex);
             IndentService.ModifySelection(currentLines, start, end, indent);
             Renumber();
             ScheduleVmUpdate();
@@ -25,13 +25,7 @@ namespace Controls{
         }
 
         public (IList<TextLine> Lines, int StartLine, int EndLine) GetSelectedLineRange(){
-            if(lineList.SelectedItems.Count == 0)
-                return (lines, lineList.SelectedIndex, lineList.SelectedIndex);
-
-            int start = lineList.Items.IndexOf(lineList.SelectedItems[0]);
-            int end = lineList.Items.IndexOf(lineList.SelectedItems[^1]);
-            if(start > end) (start, end) = (end, start);
-            return (lines, start, end);
+            return SelectionService.GetSelectedLineRange(lines, lineList.SelectedItems, lineList.SelectedIndex);
         }
     }
 }

--- a/Controls/TextEdit/TextEdit.TextBoxHandlers.cs
+++ b/Controls/TextEdit/TextEdit.TextBoxHandlers.cs
@@ -45,7 +45,6 @@ namespace Controls{
         private void TextBox_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e){
             if(sender is TextBox tb && !tb.IsKeyboardFocusWithin){
                 tb.Focus();
-                e.Handled = true;
             }
         }
 

--- a/Services/Text/SelectionService.cs
+++ b/Services/Text/SelectionService.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using Controls;
+
+namespace Services{
+    public static class SelectionService{
+        public static (IList<TextLine> Lines, int StartLine, int EndLine) GetSelectedLineRange(IList<TextLine> lines, IList selectedItems, int selectedIndex){
+            if(selectedItems.Count == 0)
+                return (lines, selectedIndex, selectedIndex);
+
+            int start = int.MaxValue;
+            int end = int.MinValue;
+            foreach(var item in selectedItems){
+                if(item is TextLine line){
+                    int idx = lines.IndexOf(line);
+                    if(idx < start) start = idx;
+                    if(idx > end) end = idx;
+                }
+            }
+            if(start == int.MaxValue) start = selectedIndex;
+            if(end == int.MinValue) end = selectedIndex;
+            if(start > end) (start, end) = (end, start);
+            return (lines, start, end);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `SelectionService` to compute line ranges
- use `SelectionService` in `TextEdit`
- let mouse clicks select items for easier range selection

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687cf220ab48832696e6412172a4a69c