### PR TITLE
Add selection shortcuts and drag functionality

### DIFF
--- a/Controls/TextEdit/TextEdit.Indent.cs
+++ b/Controls/TextEdit/TextEdit.Indent.cs
@@ -8,16 +8,19 @@ using Services;
 namespace Controls{
     public partial class TextEdit{
         public void IndentSelection(){
-            ModifySelection(true);
+            ApplyIndent(true);
         }
 
         public void UnindentSelection(){
-            ModifySelection(false);
+            ApplyIndent(false);
         }
 
-        private void ModifySelection(bool indent){
+        private void ApplyIndent(bool indent){
             (IList<TextLine> currentLines, int start, int end) = SelectionService.GetSelectedLineRange(lines, lineList.SelectedItems, lineList.SelectedIndex);
-            IndentService.ModifySelection(currentLines, start, end, indent);
+            if(indent)
+                IndentService.Indent(currentLines, start, end);
+            else
+                IndentService.Unindent(currentLines, start, end);
             Renumber();
             ScheduleVmUpdate();
         }

--- a/Controls/TextEdit/TextEdit.Selection.cs
+++ b/Controls/TextEdit/TextEdit.Selection.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Controls{
+    public partial class TextEdit{
+        private bool isDragSelecting = false;
+        private int dragStartIndex = -1;
+
+        private void OnEditorPreviewKeyDown(object sender, KeyEventArgs e){
+            if((Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control){
+                if(e.Key == Key.A){
+                    lineList.SelectAll();
+                    e.Handled = true;
+                }else if(e.Key == Key.C){
+                    CopySelection();
+                    e.Handled = true;
+                }
+            }
+        }
+
+        private void OnEditorPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e){
+            if((Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control)
+                return;
+            if(GetParentTextBox(e.OriginalSource as DependencyObject) != null)
+                return;
+            int index = IndexFromPoint(e.GetPosition(lineList));
+            if(index >= 0){
+                dragStartIndex = index;
+                isDragSelecting = true;
+                lineList.SelectedItems.Clear();
+                lineList.SelectedItems.Add(lineList.Items[index]);
+                lineList.CaptureMouse();
+                e.Handled = true;
+            }
+        }
+
+        private void OnEditorMouseMove(object sender, MouseEventArgs e){
+            if(isDragSelecting){
+                int index = IndexFromPoint(e.GetPosition(lineList));
+                if(index >= 0){
+                    lineList.SelectedItems.Clear();
+                    int start = dragStartIndex < index ? dragStartIndex : index;
+                    int end = dragStartIndex > index ? dragStartIndex : index;
+                    for(int i = start; i <= end; i++)
+                        lineList.SelectedItems.Add(lineList.Items[i]);
+                }
+            }
+        }
+
+        private void OnEditorPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e){
+            if(isDragSelecting){
+                isDragSelecting = false;
+                lineList.ReleaseMouseCapture();
+                e.Handled = true;
+            }
+        }
+
+        private int IndexFromPoint(Point point){
+            DependencyObject? element = lineList.InputHitTest(point) as DependencyObject;
+            while(element != null && element is not ListBoxItem)
+                element = VisualTreeHelper.GetParent(element);
+            if(element is ListBoxItem item)
+                return lineList.ItemContainerGenerator.IndexFromContainer(item);
+            return -1;
+        }
+
+        private static TextBox? GetParentTextBox(DependencyObject? obj){
+            while(obj != null){
+                if(obj is TextBox tb) return tb;
+                obj = VisualTreeHelper.GetParent(obj);
+            }
+            return null;
+        }
+
+        private void CopySelection(){
+            (IList<TextLine> lines, int start, int end) = GetSelectedLineRange();
+            StringBuilder sb = new();
+            for(int i = start; i <= end; i++)
+                sb.AppendLine(lines[i].Text);
+            Clipboard.SetText(sb.ToString().TrimEnd('\r', '\n'));
+        }
+    }
+}
+

--- a/Controls/TextEdit/TextEdit.xaml
+++ b/Controls/TextEdit/TextEdit.xaml
@@ -11,6 +11,10 @@
                  HorizontalAlignment="Stretch"
                  Background="White"
                  HorizontalContentAlignment="Stretch"
+                 PreviewKeyDown="OnEditorPreviewKeyDown"
+                 PreviewMouseLeftButtonDown="OnEditorPreviewMouseLeftButtonDown"
+                 PreviewMouseLeftButtonUp="OnEditorPreviewMouseLeftButtonUp"
+                 MouseMove="OnEditorMouseMove"
                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
             <ListBox.ItemTemplate>
                 <DataTemplate>

--- a/Services/Text/IndentService.cs
+++ b/Services/Text/IndentService.cs
@@ -7,6 +7,12 @@ namespace Services{
     public static class IndentService{
         // 選択された行をインデントまたはインデント解除します。
         // Tab入力はEditorSettings.IndentStringで定義されたスペースに置き換えられます。
+        public static void Indent(IList<TextLine> lines, int startLine, int endLine) =>
+            ModifySelection(lines, startLine, endLine, true);
+
+        public static void Unindent(IList<TextLine> lines, int startLine, int endLine) =>
+            ModifySelection(lines, startLine, endLine, false);
+
         public static void ModifySelection(IList<TextLine> lines, int startLine, int endLine, bool indent){
             string indentStr = EditorSettings.IndentString;
 


### PR DESCRIPTION
## Summary
- allow select all (`Ctrl+A`) and copy (`Ctrl+C`) in TextEdit
- support multi-line selection by dragging
- expose `Indent` and `Unindent` helpers in `IndentService`
- use new helper methods inside `TextEdit`

## Testing
- `dotnet build JsonEditor2.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d23ea84dc8326abc80f065f3ea777