### PR TITLE
Handle plain text conversions

### DIFF
--- a/Services/Json/TryConvertTabToJson.cs
+++ b/Services/Json/TryConvertTabToJson.cs
@@ -18,7 +18,7 @@ namespace Services{
                 Dictionary<string, string> dict = new Dictionary<string, string>();
                 string[] lines = input.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach(string line in lines){
-                    string[] parts = line.Split('\t');
+                    string[] parts = line.Split(new char[]{'\t', ' '}, 2, StringSplitOptions.RemoveEmptyEntries);
                     if(parts.Length < 2){
                         error = $"Invalid line: {line}";
                         return false;

--- a/Services/Json/TryRenameProperties.cs
+++ b/Services/Json/TryRenameProperties.cs
@@ -30,9 +30,9 @@ namespace Services{
 
                 result = string.Join("\n", convertedLines);
                 return true;
-            }catch(JsonException ex){
-                error = $"Line {ex.LineNumber}, Position {ex.BytePositionInLine}: {ex.Message}";
-                return false;
+            }catch(JsonException){
+                result = RenamePlainText(input, converter);
+                return true;
             }catch(Exception ex){
                 error = ex.Message;
                 return false;
@@ -53,6 +53,14 @@ namespace Services{
                     Rename(child, converter);
                 }
             }
+        }
+
+        private static string RenamePlainText(string input, Func<string, string> converter){
+            string[] lines = input.Replace("\r\n", "\n").Split('\n');
+            for(int i = 0; i < lines.Length; i++){
+                lines[i] = converter(lines[i]);
+            }
+            return string.Join(Environment.NewLine, lines);
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow whitespace separated values when converting to JSON
- apply case conversions to plain text if input isn't valid JSON

## Testing
- `dotnet build JsonEditor2.sln -v minimal` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687d809529e883269cd813a6f9250574