### PR TITLE
Fix startup and add app icon

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using Services;
 using ViewModels;
 
+namespace JsonEditor2{
 public partial class App : Application{
     private readonly IFileService fileService = new FileService();
     private readonly IJsonService jsonService = new JsonService();
@@ -12,4 +13,5 @@ public partial class App : Application{
         MainWindow window = new MainWindow(fileService, jsonService, textService);
         window.Show();
     }
+}
 }

--- a/JsonEditor2.csproj
+++ b/JsonEditor2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -2,7 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Controls"
-        Title="JsonEditor" Height="450" Width="800">
+        Title="JsonEditor" Height="450" Width="800"
+        Icon="Resources/Icons/AppIcon.png">
     <DockPanel>
         <ToolBarTray DockPanel.Dock="Top">
             <ToolBar>


### PR DESCRIPTION
## Summary
- ensure App.xaml.cs is in the `JsonEditor2` namespace so the WPF startup logic runs
- target `net8.0-windows`
- set the window icon to `AppIcon.png`

## Testing
- `dotnet build JsonEditor2.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec4f9d2a483269ae4c864778cc566